### PR TITLE
fix encoded

### DIFF
--- a/httprequest/httprequest.js
+++ b/httprequest/httprequest.js
@@ -145,12 +145,20 @@ exports.install = function(instance) {
 
 			switch (options.stringify) {
 				case 'json':
-					opt.body = JSON.stringify(flowdata.data);
-					opt.type = 'json';
+					if (opt.method === 'GET' || opt.method === 'HEAD') {
+						opt.query = JSON.stringify(flowdata.data);
+					} else {
+						opt.body = JSON.stringify(flowdata.data);
+						opt.type = 'json';
+					}
 					break;
 				case 'raw':
-					opt.body = flowdata.data instanceof Buffer ? flowdata.data : Buffer.from(flowdata.data);
-					opt.type = 'raw';
+					if (opt.method === 'GET' || opt.method === 'HEAD') {
+						opt.query = flowdata.data instanceof Buffer ? flowdata.data : Buffer.from(flowdata.data);
+					} else {
+						opt.body = flowdata.data instanceof Buffer ? flowdata.data : Buffer.from(flowdata.data);
+						opt.type = 'raw';
+					}
 					break;
 				case 'encoded':
 					if (opt.method === 'GET' || opt.method === 'HEAD') {


### PR DESCRIPTION
fix encoded for get and head in json  and raw calls

Fix this errors:

`Error [ERR_STREAM_WRITE_AFTER_END]: write after end - Error [ERR_STREAM_WRITE_AFTER_END]: write after end at writeAfterEnd (_http_outgoing.js:668:15) at ClientRequest.end (_http_outgoing.js:788:7) at request_call (/www/www/12_69:8020-241-10/node_modules/total4/utils.js:764:7) at global.REQUEST (/www/www/12_69:8020-241-10/node_modules/total4/utils.js:620:3) at Object.instance.custom.send (/www/www/12_69:8020-241-10/flow/httprequest.js:165:4) at Component.<anonymous> (/www/www/12_69:8020-241-10/flow/httprequest.js:76:26) at Component.emit (/www/www/12_69:8020-241-10/tmp/flow.package/index.js:625:11) at Component.send (/www/www/12_69:8020-241-10/tmp/flow.package/index.js:984:41) at Component.send2 (/www/www/12_69:8020-241-10/tmp/flow.package/index.js:837:15) at Timeout._onTimeout (/www/www/12_69:8020-241-10/flow/timer.js:80:56)`
